### PR TITLE
Changed aspInstance parameter type to int

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -68,7 +68,7 @@
         },
         "aspInstances": {
             "type": "int",
-            "defaultValue": "1"
+            "defaultValue": 1
         }
     },
     "variables": {

--- a/azure/template.json
+++ b/azure/template.json
@@ -67,7 +67,7 @@
             "defaultValue": "1"
         },
         "aspInstances": {
-            "type": "string",
+            "type": "int",
             "defaultValue": "1"
         }
     },


### PR DESCRIPTION
The following error occurred in the deployment:

  "error": {
    "code": "InvalidTemplate",
    "message": "Deployment template validation failed: 'The provided value for the template parameter 'aspInstances' at line '32' and column '25' is not valid.'."
  }

Updated the aspInstance parameter to type "int".