### PR TITLE
Amended the VacancyEventHub connection string to ReadWrite

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -244,7 +244,7 @@
                             },
                             {
                                 "name": "VacancyEventHub",
-                                "value": "[reference('event-hub').outputs.HubEndpointReadOnly.value]"
+                                "value": "[reference('event-hub').outputs.HubEndpoint.value]"
                             },
                             {
                                 "name": "FUNCTIONS_EXTENSION_VERSION",


### PR DESCRIPTION
It has been requested that the Azure Function App be able to send to the Event Hub so the ARM template has been updated to input the ReadWrite shared access policy as the VacancyEventHub connection string rather than just the Read shared access policy.