### PR TITLE
Added VacancyEventHub connection string and appServiceVirtualApplications parameters for worker app service

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -353,7 +353,23 @@
                                 "name": "VacancyAnalyticEventsSqlDbConnectionString",
                                 "connectionString": "[parameters('databaseConnectionString')]",
                                 "type": "Custom"
+                            },
+                            {
+                                "name": "VacancyEventHub",
+                                "value": "[reference('event-hub').outputs.HubEndpointReadOnly.value]"
                             }
+                        ]
+                    },
+                    "appServiceVirtualApplications": {
+                        "value": [
+                          {
+                            "virtualPath": "/",
+                            "physicalPath": "site\\wwwroot"
+                          },
+                          {
+                            "virtualPath": "/Vacancy.Analytics.Jobs",
+                            "physicalPath": "site\\wwwroot\\app_data\\jobs\\continuous\\Vacancy.Analytics.Jobs"
+                          }
                         ]
                     }
                 }

--- a/azure/template.json
+++ b/azure/template.json
@@ -356,7 +356,8 @@
                             },
                             {
                                 "name": "VacancyEventHub",
-                                "value": "[reference('event-hub').outputs.HubEndpointReadOnly.value]"
+                                "value": "[reference('event-hub').outputs.HubEndpointReadOnly.value]",
+                                "type": "Custom"
                             }
                         ]
                     },


### PR DESCRIPTION
- Added the "VacancyEventHub" connection string to the list of appServiceConnectionStrings for the worker job app service. This was a missing connection string.
- Added the appServiceVirtualApplications section to the worker job app service. Added a custom virtual path called "/Vacancy.Analytics.Jobs" so that the Azure App Service Deploy task in Azure DevOps can deploy to this virtual application.