### PR TITLE
Change ipSecurityRestrictions to concat new parameters wafOutboundIpAddresses and dfeOutboundIpAddresses

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -89,7 +89,11 @@
             "type": "string",
             "defaultValue": ""
         },
-        "ipSecurityRestrictions": {
+        "wafOutboundIpAddresses": {
+           "type": "array",
+           "defaultValue": []
+        },
+        "dfeOutboundIpAddresses": {
            "type": "array",
            "defaultValue": []
         }
@@ -276,7 +280,7 @@
                         "value": "[resourceGroup().name]"
                     },
                     "ipSecurityRestrictions": {
-                        "value": "[parameters('ipSecurityRestrictions')]"
+                        "value": "[concat(parameters('wafOutboundIpAddresses'), parameters('dfeOutboundIpAddresses'))]"
                     },
                     "functionAppAppSettings": {
                         "value": [


### PR DESCRIPTION
- Added two new parameters:
wafOutboundIpAddresses
dfeOutboundIpAddresses

- Updated ipSecurityRestrictions parameter for the function-app deployment to concat the two new parameters.